### PR TITLE
Support Navigation Based Transition

### DIFF
--- a/Example/View2ViewTransitionExample/View2ViewTransitionExample.xcodeproj/project.pbxproj
+++ b/Example/View2ViewTransitionExample/View2ViewTransitionExample.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		4389BB951D73FB63000CD88C /* PresentAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4389BB901D73FB63000CD88C /* PresentAnimationController.swift */; };
 		4389BB961D73FB63000CD88C /* TransitionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4389BB911D73FB63000CD88C /* TransitionController.swift */; };
 		4389BBAF1D74311E000CD88C /* UIView+SnapshotImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4389BBAE1D74311E000CD88C /* UIView+SnapshotImage.swift */; };
+		43A6266A1D7E792E00E86FEC /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A626691D7E792E00E86FEC /* MenuViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		4389BB901D73FB63000CD88C /* PresentAnimationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PresentAnimationController.swift; path = ../../../Sources/PresentAnimationController.swift; sourceTree = "<group>"; };
 		4389BB911D73FB63000CD88C /* TransitionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TransitionController.swift; path = ../../../Sources/TransitionController.swift; sourceTree = "<group>"; };
 		4389BBAE1D74311E000CD88C /* UIView+SnapshotImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIView+SnapshotImage.swift"; path = "../../../Sources/UIView+SnapshotImage.swift"; sourceTree = "<group>"; };
+		43A626691D7E792E00E86FEC /* MenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,6 +70,7 @@
 			isa = PBXGroup;
 			children = (
 				4389BB761D73FA96000CD88C /* AppDelegate.swift */,
+				43A626691D7E792E00E86FEC /* MenuViewController.swift */,
 				4389BB891D73FB3F000CD88C /* PresentingViewController.swift */,
 				4389BB881D73FB3F000CD88C /* PresentedViewController.swift */,
 				4389BB7D1D73FA96000CD88C /* Assets.xcassets */,
@@ -162,6 +165,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4389BB941D73FB63000CD88C /* DismissInteractiveTransition.swift in Sources */,
+				43A6266A1D7E792E00E86FEC /* MenuViewController.swift in Sources */,
 				4389BB951D73FB63000CD88C /* PresentAnimationController.swift in Sources */,
 				4389BBAF1D74311E000CD88C /* UIView+SnapshotImage.swift in Sources */,
 				4389BB771D73FA96000CD88C /* AppDelegate.swift in Sources */,
@@ -311,6 +315,7 @@
 				4389BB871D73FA96000CD88C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Example/View2ViewTransitionExample/View2ViewTransitionExample/AppDelegate.swift
+++ b/Example/View2ViewTransitionExample/View2ViewTransitionExample/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
-        self.window?.rootViewController = PresentingViewController()
+        self.window?.rootViewController = MenuViewController()
         self.window?.makeKeyAndVisible()
         
         return true

--- a/Example/View2ViewTransitionExample/View2ViewTransitionExample/AppDelegate.swift
+++ b/Example/View2ViewTransitionExample/View2ViewTransitionExample/AppDelegate.swift
@@ -15,12 +15,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         
-        let rootViewController = MenuViewController()
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
-        self.window?.rootViewController = rootViewController
+        self.window?.rootViewController = MenuViewController()
         self.window?.makeKeyAndVisible()
-        
-        rootViewController.presentViewController(PresentingViewController(), animated: false, completion: nil)
         
         return true
     }

--- a/Example/View2ViewTransitionExample/View2ViewTransitionExample/AppDelegate.swift
+++ b/Example/View2ViewTransitionExample/View2ViewTransitionExample/AppDelegate.swift
@@ -15,9 +15,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         
+        let rootViewController = MenuViewController()
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
-        self.window?.rootViewController = MenuViewController()
+        self.window?.rootViewController = rootViewController
         self.window?.makeKeyAndVisible()
+        
+        rootViewController.presentViewController(PresentingViewController(), animated: false, completion: nil)
         
         return true
     }

--- a/Example/View2ViewTransitionExample/View2ViewTransitionExample/MenuViewController.swift
+++ b/Example/View2ViewTransitionExample/View2ViewTransitionExample/MenuViewController.swift
@@ -1,0 +1,123 @@
+//
+//  MenuViewController.swift
+//  View2ViewTransitionExample
+//
+//  Created by naru on 2016/09/06.
+//  Copyright © 2016年 naru. All rights reserved.
+//
+
+import UIKit
+
+class MenuViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = UIColor.whiteColor()
+
+        self.view.addSubview(self.tableView)
+    }
+    
+    // MARK: Constants
+    
+    private struct Constants {
+        static let Font: UIFont = UIFont.systemFontOfSize(15.0)
+        static let ButtonSize: CGSize = CGSize(width: 200.0, height: 44.0)
+    }
+    
+    // MARK: Elements
+    
+    lazy var tableView: UITableView = {
+        let tableView: UITableView = UITableView(frame: self.view.bounds, style: .Grouped)
+        tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.registerClass(TableViewSectionHeader.self, forHeaderFooterViewReuseIdentifier: "header")
+        tableView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        tableView.delegate = self
+        tableView.dataSource = self
+        return tableView
+    }()
+}
+
+extension MenuViewController: UITableViewDataSource {
+
+    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 2
+    }
+    
+    func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return tableView.dequeueReusableHeaderFooterViewWithIdentifier("header")
+    }
+    
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCellWithIdentifier("cell", forIndexPath: indexPath)
+        self.configulerCell(cell, at: indexPath)
+        return cell
+    }
+    
+    func configulerCell(cell: UITableViewCell, at indexPath: NSIndexPath) {
+        cell.accessoryType = .DisclosureIndicator
+        cell.textLabel?.font = UIFont.systemFontOfSize(14.0)
+        switch indexPath.row {
+        case 0:
+            cell.textLabel?.text = "Present and Dismiss"
+        case 1:
+            cell.textLabel?.text = "Push and Pop"
+        default:
+            break
+        }
+    }
+}
+
+extension MenuViewController: UITableViewDelegate {
+
+    func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return TableViewSectionHeader.Constants.Height
+    }
+    
+    func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+        return 44.0
+    }
+    
+    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        switch indexPath.row {
+        case 0:
+            self.presentViewController(PresentingViewController(), animated: true, completion: nil)
+        case 1:
+            self.presentViewController(UINavigationController(rootViewController: PresentingViewController()), animated: true, completion: nil)
+        default:
+            break
+        }
+        tableView.deselectRowAtIndexPath(indexPath, animated: true)
+    }
+}
+
+private class TableViewSectionHeader: UITableViewHeaderFooterView {
+    
+    struct Constants {
+        static let Height: CGFloat = 60.0
+        static let Width: CGFloat = UIScreen.mainScreen().bounds.width
+        static let Font: UIFont = UIFont.boldSystemFontOfSize(14.0)
+    }
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        
+        self.contentView.addSubview(self.titleLabel)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    lazy var titleLabel: UILabel = {
+        let frame: CGRect = CGRect(x: 12.0, y: Constants.Height - ceil(Constants.Font.lineHeight) - 8.0, width: Constants.Width - 24.0, height: ceil(Constants.Font.lineHeight))
+        let label: UILabel = UILabel(frame: frame)
+        label.font = Constants.Font
+        label.text = "Examples of View2View Transition"
+        label.textColor = UIColor(white: 0.3, alpha: 1.0)
+        return label
+    }()
+}

--- a/Example/View2ViewTransitionExample/View2ViewTransitionExample/MenuViewController.swift
+++ b/Example/View2ViewTransitionExample/View2ViewTransitionExample/MenuViewController.swift
@@ -17,6 +17,16 @@ class MenuViewController: UIViewController {
         self.view.addSubview(self.tableView)
     }
     
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        guard !self.isViewControllerInitialized else {
+            return
+        }
+        self.isViewControllerInitialized = true
+        self.presentViewController(PresentingViewController(), animated: true, completion: nil)
+    }
+    
     // MARK: Constants
     
     private struct Constants {
@@ -25,6 +35,8 @@ class MenuViewController: UIViewController {
     }
     
     // MARK: Elements
+    
+    private var isViewControllerInitialized: Bool = false
     
     lazy var tableView: UITableView = {
         let tableView: UITableView = UITableView(frame: self.view.bounds, style: .Grouped)

--- a/Example/View2ViewTransitionExample/View2ViewTransitionExample/PresentedViewController.swift
+++ b/Example/View2ViewTransitionExample/View2ViewTransitionExample/PresentedViewController.swift
@@ -12,9 +12,13 @@ class PresentedViewController: UIViewController, UICollectionViewDelegate, UICol
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.addSubview(self.collectionView)
+        self.edgesForExtendedLayout = .None
+        
+        self.navigationItem.titleView = self.titleLabel
+        self.navigationItem.leftBarButtonItem = self.backItem
         self.view.backgroundColor = UIColor.whiteColor()
         
+        self.view.addSubview(self.collectionView)
         self.view.addSubview(self.closeButton)
     }
 
@@ -55,9 +59,23 @@ class PresentedViewController: UIViewController, UICollectionViewDelegate, UICol
         let frame: CGRect = CGRect(x: 0.0, y: 20.0, width: 60.0, height: 40.0)
         let button: UIButton = UIButton(frame: frame)
         button.setTitle("Close", forState: .Normal)
-        button.setTitleColor(UIColor.grayColor(), forState: .Normal)
+        button.setTitleColor(self.view.tintColor, forState: .Normal)
         button.addTarget(self, action: #selector(onCloseButtonClicked(_:)), forControlEvents: .TouchUpInside)
         return button
+    }()
+    
+    lazy var titleLabel: UILabel = {
+        let font: UIFont = UIFont.boldSystemFontOfSize(16.0)
+        let label: UILabel = UILabel()
+        label.font = font
+        label.text = "Detail"
+        label.sizeToFit()
+        return label
+    }()
+    
+    lazy var backItem: UIBarButtonItem = {
+        let item: UIBarButtonItem = UIBarButtonItem(title: "< Back", style: .Plain, target: self, action: #selector(onBackItemClicked(_:)))
+        return item
     }()
     
     // MARK: CollectionView Data Source
@@ -87,7 +105,18 @@ class PresentedViewController: UIViewController, UICollectionViewDelegate, UICol
         
         let indexPath: NSIndexPath = self.collectionView.indexPathsForVisibleItems().first!
         self.transitionController.userInfo = ["destinationIndexPath": indexPath, "initialIndexPath": indexPath]
+        
         self.dismissViewControllerAnimated(true, completion: nil)
+    }
+    
+    func onBackItemClicked(sender: AnyObject) {
+        
+        let indexPath: NSIndexPath = self.collectionView.indexPathsForVisibleItems().first!
+        self.transitionController.userInfo = ["destinationIndexPath": indexPath, "initialIndexPath": indexPath]
+        
+        if let navigationController = self.navigationController {
+            navigationController.popViewControllerAnimated(true)
+        }
     }
     
     // MARK: Gesture Delegate

--- a/Example/View2ViewTransitionExample/View2ViewTransitionExample/PresentingViewController.swift
+++ b/Example/View2ViewTransitionExample/View2ViewTransitionExample/PresentingViewController.swift
@@ -14,6 +14,9 @@ class PresentingViewController: UIViewController, UICollectionViewDelegate, UICo
         super.viewDidLoad()
         self.view.backgroundColor = UIColor.whiteColor()
         
+        self.navigationItem.titleView = self.titleLabel
+        self.navigationItem.leftBarButtonItem = self.closeItem
+        
         self.view.addSubview(self.collectionView)
     }
     
@@ -41,6 +44,20 @@ class PresentingViewController: UIViewController, UICollectionViewDelegate, UICo
         return collectionView
     }()
     
+    lazy var titleLabel: UILabel = {
+        let font: UIFont = UIFont(name: "Futura-Medium", size: 16.0)!
+        let label: UILabel = UILabel()
+        label.font = font
+        label.text = "All"
+        label.sizeToFit()
+        return label
+    }()
+    
+    lazy var closeItem: UIBarButtonItem = {
+        let item: UIBarButtonItem = UIBarButtonItem(title: "Close", style: .Plain, target: self, action: #selector(onCloseButtonClicked(_:)))
+        return item
+    }()
+    
     // MARK: CollectionView Delegate
     
     func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
@@ -48,11 +65,35 @@ class PresentingViewController: UIViewController, UICollectionViewDelegate, UICo
         self.selectedIndexPath = indexPath
         
         let presentedViewController: PresentedViewController = PresentedViewController()
-        presentedViewController.transitioningDelegate = transitionController
-        presentedViewController.transitionController = transitionController
         
-        transitionController.userInfo = ["destinationIndexPath": indexPath, "initialIndexPath": indexPath]
-        transitionController.present(viewController: presentedViewController, on: self, attached: presentedViewController, completion: nil)
+        presentedViewController.transitionController = self.transitionController
+        self.transitionController.userInfo = ["destinationIndexPath": indexPath, "initialIndexPath": indexPath]
+        
+        // This example will push view controller if presenting view controller has navigation controller.
+        // Otherwise, present onother view controller
+        if let navigationController = self.navigationController {
+            
+            // Set transitionController as a navigation controller delegate and push.
+            navigationController.delegate = transitionController
+            transitionController.push(viewController: presentedViewController, on: self, attached: presentedViewController)
+        
+        } else {
+            
+            // Set transitionController as a transition delegate and present.
+            presentedViewController.transitioningDelegate = transitionController
+            transitionController.present(viewController: presentedViewController, on: self, attached: presentedViewController, completion: nil)
+        }
+        
+        collectionView.deselectItemAtIndexPath(indexPath, animated: true)
+    }
+    
+    func scrollViewDidScroll(scrollView: UIScrollView) {
+       
+        if let _ = self.navigationController { return }
+        
+        if scrollView.contentOffset.y <= -100.0 {
+            self.dismissViewControllerAnimated(true, completion: nil)
+        }
     }
     
     // MARK: CollectionView Data Source
@@ -74,6 +115,12 @@ class PresentingViewController: UIViewController, UICollectionViewDelegate, UICo
         cell.content.image = UIImage(named: "image\(number)")
         
         return cell
+    }
+    
+    // MARK: Actions
+    
+    func onCloseButtonClicked(sender: AnyObject) {
+        self.dismissViewControllerAnimated(true, completion: nil)
     }
 }
 

--- a/Example/View2ViewTransitionExample/View2ViewTransitionExample/PresentingViewController.swift
+++ b/Example/View2ViewTransitionExample/View2ViewTransitionExample/PresentingViewController.swift
@@ -70,7 +70,7 @@ class PresentingViewController: UIViewController, UICollectionViewDelegate, UICo
         self.transitionController.userInfo = ["destinationIndexPath": indexPath, "initialIndexPath": indexPath]
         
         // This example will push view controller if presenting view controller has navigation controller.
-        // Otherwise, present onother view controller
+        // Otherwise, present another view controller
         if let navigationController = self.navigationController {
             
             // Set transitionController as a navigation controller delegate and push.

--- a/Sources/DismissAnimationController.swift
+++ b/Sources/DismissAnimationController.swift
@@ -108,7 +108,9 @@ public final class DismissAnimationController: NSObject, UIViewControllerAnimate
         if transitionContext.isInteractive() {
             
             UIView.animateWithDuration(duration, delay: 0.0, usingSpringWithDamping: 1.0, initialSpringVelocity: 0.0, options: options, animations: {
+                
                 fromViewControllerView.alpha = CGFloat.min
+         
             }, completion: nil)
             
         } else {
@@ -124,7 +126,8 @@ public final class DismissAnimationController: NSObject, UIViewControllerAnimate
                     
                 self.destinationTransitionView.removeFromSuperview()
                 self.initialTransitionView.removeFromSuperview()
-                if isNeedToControlToViewController {
+                
+                if isNeedToControlToViewController && self.transitionController.type == .Presenting {
                     toViewControllerView.removeFromSuperview()
                 }
                 

--- a/Sources/DismissInteractiveTransition.swift
+++ b/Sources/DismissInteractiveTransition.swift
@@ -35,7 +35,14 @@ public class DismissInteractiveTransition: UIPercentDrivenInteractiveTransition 
             
             self.interactionInProgress = true
             self.initialPanPoint = panGestureRecognizer.locationInView(panGestureRecognizer.view)
-            self.transitionController.presentedViewController.dismissViewControllerAnimated(true, completion: nil)
+            
+            switch self.transitionController.type {
+            case .Presenting:
+                self.transitionController.presentedViewController.dismissViewControllerAnimated(true, completion: nil)
+            case .Pushing:
+                self.transitionController.presentedViewController.navigationController!.popViewControllerAnimated(true)
+            }
+            
             return
         }
         
@@ -114,6 +121,15 @@ public class DismissInteractiveTransition: UIPercentDrivenInteractiveTransition 
                     self.animationController.initialTransitionView.frame = self.animationController.initialFrame
                     
                 }, completion: { _ in
+                    
+                    if self.transitionController.type == .Pushing {
+                            
+                        self.animationController.destinationTransitionView.removeFromSuperview()
+                        self.animationController.initialTransitionView.removeFromSuperview()
+                            
+                        self.animationController.initialView.hidden = false
+                        self.animationController.destinationView.hidden = false
+                    }
                     
                     self.transitionController.presentingViewController.view.userInteractionEnabled = true
                     self.animationController.initialView.hidden = false

--- a/Sources/TransitionController.swift
+++ b/Sources/TransitionController.swift
@@ -8,11 +8,18 @@
 
 import UIKit
 
-public final class TransitionController: NSObject {
+public enum TransitionControllerType {
+    case Presenting
+    case Pushing
+}
 
+public final class TransitionController: NSObject {
+    
     public var debuging: Bool = false
     
     public var userInfo: [String: AnyObject]? = nil
+    
+    private(set) var type: TransitionControllerType = .Presenting
     
     public lazy var presentAnimationController: PresentAnimationController = {
         let controller: PresentAnimationController = PresentAnimationController()
@@ -46,6 +53,8 @@ public final class TransitionController: NSObject {
         self.presentingViewController = presentingViewController
         self.presentedViewController = presentedViewController
         
+        self.type = .Presenting
+        
         // Present
         presentingViewController.presentViewController(presentedViewController, animated: true, completion: completion)
     }
@@ -60,8 +69,55 @@ public final class TransitionController: NSObject {
         self.presentingViewController = presentingViewController
         self.presentedViewController = presentedViewController
 
+        self.type = .Presenting
+        
         // Present
         presentingViewController.presentViewController(presentedViewController, animated: true, completion: completion)
+    }
+    
+    /// Type Safe Push for Swift
+    public func push<T: View2ViewTransitionPresented, U: View2ViewTransitionPresenting where T: UIViewController, U: UIViewController>(viewController presentedViewController: T, on presentingViewController: U, attached: UIViewController) {
+        
+        guard let navigationController = presentingViewController.navigationController else {
+            if self.debuging {
+                debugPrint("View2ViewTransition << Cannot Find Navigation Controller for Presenting View Controller")
+            }
+            return
+        }
+        
+        let pan = UIPanGestureRecognizer(target: dismissInteractiveTransition, action: #selector(dismissInteractiveTransition.handlePanGesture(_:)))
+        attached.view.addGestureRecognizer(pan)
+        
+        self.presentingViewController = presentingViewController
+        self.presentedViewController = presentedViewController
+        
+        self.type = .Pushing
+        
+        // Push
+        navigationController.pushViewController(presentedViewController, animated: true)
+    }
+    
+    @available(*, unavailable)
+    /// Push for Objective-C
+    public func push(viewController presentedViewController: UIViewController, on presentingViewController: UIViewController, attached: UIViewController) {
+        
+        guard let navigationController = presentingViewController.navigationController else {
+            if self.debuging {
+                debugPrint("View2ViewTransition << Cannot Find Navigation Controller for Presenting View Controller")
+            }
+            return
+        }
+        
+        let pan = UIPanGestureRecognizer(target: dismissInteractiveTransition, action: #selector(dismissInteractiveTransition.handlePanGesture(_:)))
+        attached.view.addGestureRecognizer(pan)
+        
+        self.presentingViewController = presentingViewController
+        self.presentedViewController = presentedViewController
+        
+        self.type = .Pushing
+        
+        // Push
+        navigationController.pushViewController(presentedViewController, animated: true)
     }
 }
 
@@ -77,5 +133,26 @@ extension TransitionController: UIViewControllerTransitioningDelegate {
     
     public func interactionControllerForDismissal(animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         return dismissInteractiveTransition.interactionInProgress ? dismissInteractiveTransition : nil
+    }
+}
+
+extension TransitionController: UINavigationControllerDelegate {
+
+    public func navigationController(navigationController: UINavigationController, animationControllerForOperation operation: UINavigationControllerOperation, fromViewController fromVC: UIViewController, toViewController toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        switch operation {
+        case .Push:
+            return self.presentAnimationController
+        case .Pop:
+            return self.dismissAnimationController
+        default:
+            return nil
+        }
+    }
+    
+    public func navigationController(navigationController: UINavigationController, interactionControllerForAnimationController animationController: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
+        if animationController === self.dismissAnimationController && self.dismissInteractiveTransition.interactionInProgress {
+            return self.dismissInteractiveTransition
+        }
+        return nil
     }
 }


### PR DESCRIPTION
issue #4

- TransitionController supports custom push/pop transition
- Update example for push/pop

__For push/pop__

```swift
if let navigationController = self.navigationController {
   navigationController.delegate = transitionController
   transitionController.push(viewController: presentedViewController, on: self, attached: presentedViewController)
}
```

__For present/dismiss__

```swift
presentedViewController.transitioningDelegate = transitionController
transitionController.present(viewController: presentedViewController, on: self, attached: presentedViewController, completion: nil)
```

You need not to add any settings to support push/pop.
